### PR TITLE
forced conda to provide direct paths

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,16 +1,16 @@
 certifi==2020.12.5
 chardet==3.0.4
-click @ file:///home/linux1/recipes/ci/click_1610990599742/work
+click==7.1.2
 Cython==0.29.14
 datefinder-lexpredict==0.6.2.1
 dateparser==0.7.2
 docopt==0.6.2
-Flask @ file:///home/ktietz/src/ci/flask_1611932660458/work
+Flask==1.1.2
 gensim==3.8.3
 idna==2.10
 itsdangerous==1.1.0
 jellyfish==0.6.1
-Jinja2 @ file:///tmp/build/80754af9/jinja2_1612213139570/work
+Jinja2==2.11.3
 joblib==0.14.0
 lexnlp==1.8.0
 MarkupSafe==1.1.1
@@ -22,7 +22,7 @@ numpy==1.19.1
 olefile==0.46
 pandas==0.24.2
 pdfminer==20191125
-Pillow @ file:///C:/ci/pillow_1615224175364/work
+Pillow==8.1.2
 pycountry==20.7.3
 PyPDF2==1.26.0
 pytesseract==0.3.7
@@ -42,5 +42,5 @@ tzlocal==2.1
 Unidecode==1.1.1
 urllib3==1.25.11
 us==2.0.2
-Werkzeug @ file:///home/ktietz/src/ci/werkzeug_1611932622770/work
+Werkzeug==1.0.1
 wincertstore==0.2


### PR DESCRIPTION
fixed issue with pip freeze giving out conda paths instead of specific version numbers